### PR TITLE
Upgrade Payload CMS packages to 3.85.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "goldgetters",
       "version": "0.1.0",
       "dependencies": {
-        "@payloadcms/db-sqlite": "3.84.1",
-        "@payloadcms/next": "3.84.1",
-        "@payloadcms/richtext-lexical": "3.84.1",
-        "@payloadcms/ui": "3.84.1",
+        "@payloadcms/db-sqlite": "3.85.0",
+        "@payloadcms/next": "3.85.0",
+        "@payloadcms/richtext-lexical": "3.85.0",
+        "@payloadcms/ui": "3.85.0",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-navigation-menu": "^1.2.14",
         "@radix-ui/react-slot": "^1.2.4",
@@ -22,7 +22,7 @@
         "lucide-react": "^0.542.0",
         "next": "^16.2.6",
         "nodemailer": "^8.0.8",
-        "payload": "3.84.1",
+        "payload": "3.85.0",
         "radix-ui": "^1.4.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -2745,153 +2745,28 @@
       }
     },
     "node_modules/@payloadcms/db-sqlite": {
-      "version": "3.84.1",
-      "resolved": "https://registry.npmjs.org/@payloadcms/db-sqlite/-/db-sqlite-3.84.1.tgz",
-      "integrity": "sha512-OJWXMaq4XvBeXwummIo6RcpPM4eCpksTw+l1XX9xYhGumyh/Jw1INkNQ3a6SoLncxJvPAq6pqiYVPBposcYI+Q==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@payloadcms/db-sqlite/-/db-sqlite-3.85.0.tgz",
+      "integrity": "sha512-QoXjDPq0V5FJoRODiGi7b6dENr2ziNbAtHrshFUld5Lncc+d1ZurxTgCyx9g6f6mFz0pmcnl5PiFpkSVmxhArg==",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "0.14.0",
-        "@payloadcms/drizzle": "3.84.1",
+        "@payloadcms/drizzle": "3.85.0",
         "console-table-printer": "2.12.1",
         "drizzle-kit": "0.31.7",
         "drizzle-orm": "0.45.2",
         "prompts": "2.4.2",
         "to-snake-case": "1.0.0",
-        "uuid": "11.1.0"
+        "uuid": "13.0.2"
       },
       "peerDependencies": {
-        "payload": "3.84.1"
-      }
-    },
-    "node_modules/@payloadcms/db-sqlite/node_modules/drizzle-orm": {
-      "version": "0.45.2",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
-      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@aws-sdk/client-rds-data": ">=3",
-        "@cloudflare/workers-types": ">=4",
-        "@electric-sql/pglite": ">=0.2.0",
-        "@libsql/client": ">=0.10.0",
-        "@libsql/client-wasm": ">=0.10.0",
-        "@neondatabase/serverless": ">=0.10.0",
-        "@op-engineering/op-sqlite": ">=2",
-        "@opentelemetry/api": "^1.4.1",
-        "@planetscale/database": ">=1.13",
-        "@prisma/client": "*",
-        "@tidbcloud/serverless": "*",
-        "@types/better-sqlite3": "*",
-        "@types/pg": "*",
-        "@types/sql.js": "*",
-        "@upstash/redis": ">=1.34.7",
-        "@vercel/postgres": ">=0.8.0",
-        "@xata.io/client": "*",
-        "better-sqlite3": ">=7",
-        "bun-types": "*",
-        "expo-sqlite": ">=14.0.0",
-        "gel": ">=2",
-        "knex": "*",
-        "kysely": "*",
-        "mysql2": ">=2",
-        "pg": ">=8",
-        "postgres": ">=3",
-        "sql.js": ">=1",
-        "sqlite3": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/client-rds-data": {
-          "optional": true
-        },
-        "@cloudflare/workers-types": {
-          "optional": true
-        },
-        "@electric-sql/pglite": {
-          "optional": true
-        },
-        "@libsql/client": {
-          "optional": true
-        },
-        "@libsql/client-wasm": {
-          "optional": true
-        },
-        "@neondatabase/serverless": {
-          "optional": true
-        },
-        "@op-engineering/op-sqlite": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@planetscale/database": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "@tidbcloud/serverless": {
-          "optional": true
-        },
-        "@types/better-sqlite3": {
-          "optional": true
-        },
-        "@types/pg": {
-          "optional": true
-        },
-        "@types/sql.js": {
-          "optional": true
-        },
-        "@upstash/redis": {
-          "optional": true
-        },
-        "@vercel/postgres": {
-          "optional": true
-        },
-        "@xata.io/client": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "bun-types": {
-          "optional": true
-        },
-        "expo-sqlite": {
-          "optional": true
-        },
-        "gel": {
-          "optional": true
-        },
-        "knex": {
-          "optional": true
-        },
-        "kysely": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "postgres": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        },
-        "sql.js": {
-          "optional": true
-        },
-        "sqlite3": {
-          "optional": true
-        }
+        "payload": "3.85.0"
       }
     },
     "node_modules/@payloadcms/drizzle": {
-      "version": "3.84.1",
-      "resolved": "https://registry.npmjs.org/@payloadcms/drizzle/-/drizzle-3.84.1.tgz",
-      "integrity": "sha512-n/1fgH3fh6omGNecjhOJ32wrxio5ph2VhfQDwMvSEViTUPD9JXp0yJiOUEqzYK/cxoRQWfwBIbvgzpC/a6FsEw==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@payloadcms/drizzle/-/drizzle-3.85.0.tgz",
+      "integrity": "sha512-G5UJ4V0QRuWcoKDBF8NHktA1MJ5lgeTOL3D2rJXNAJlaq+jDf6jz0vXFguiYzbEcVRyS81GifsQsb1ldgAfJcQ==",
       "license": "MIT",
       "dependencies": {
         "console-table-printer": "2.12.1",
@@ -2899,141 +2774,16 @@
         "drizzle-orm": "0.45.2",
         "prompts": "2.4.2",
         "to-snake-case": "1.0.0",
-        "uuid": "11.1.0"
+        "uuid": "13.0.2"
       },
       "peerDependencies": {
-        "payload": "3.84.1"
-      }
-    },
-    "node_modules/@payloadcms/drizzle/node_modules/drizzle-orm": {
-      "version": "0.45.2",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
-      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@aws-sdk/client-rds-data": ">=3",
-        "@cloudflare/workers-types": ">=4",
-        "@electric-sql/pglite": ">=0.2.0",
-        "@libsql/client": ">=0.10.0",
-        "@libsql/client-wasm": ">=0.10.0",
-        "@neondatabase/serverless": ">=0.10.0",
-        "@op-engineering/op-sqlite": ">=2",
-        "@opentelemetry/api": "^1.4.1",
-        "@planetscale/database": ">=1.13",
-        "@prisma/client": "*",
-        "@tidbcloud/serverless": "*",
-        "@types/better-sqlite3": "*",
-        "@types/pg": "*",
-        "@types/sql.js": "*",
-        "@upstash/redis": ">=1.34.7",
-        "@vercel/postgres": ">=0.8.0",
-        "@xata.io/client": "*",
-        "better-sqlite3": ">=7",
-        "bun-types": "*",
-        "expo-sqlite": ">=14.0.0",
-        "gel": ">=2",
-        "knex": "*",
-        "kysely": "*",
-        "mysql2": ">=2",
-        "pg": ">=8",
-        "postgres": ">=3",
-        "sql.js": ">=1",
-        "sqlite3": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/client-rds-data": {
-          "optional": true
-        },
-        "@cloudflare/workers-types": {
-          "optional": true
-        },
-        "@electric-sql/pglite": {
-          "optional": true
-        },
-        "@libsql/client": {
-          "optional": true
-        },
-        "@libsql/client-wasm": {
-          "optional": true
-        },
-        "@neondatabase/serverless": {
-          "optional": true
-        },
-        "@op-engineering/op-sqlite": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@planetscale/database": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "@tidbcloud/serverless": {
-          "optional": true
-        },
-        "@types/better-sqlite3": {
-          "optional": true
-        },
-        "@types/pg": {
-          "optional": true
-        },
-        "@types/sql.js": {
-          "optional": true
-        },
-        "@upstash/redis": {
-          "optional": true
-        },
-        "@vercel/postgres": {
-          "optional": true
-        },
-        "@xata.io/client": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "bun-types": {
-          "optional": true
-        },
-        "expo-sqlite": {
-          "optional": true
-        },
-        "gel": {
-          "optional": true
-        },
-        "knex": {
-          "optional": true
-        },
-        "kysely": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "postgres": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        },
-        "sql.js": {
-          "optional": true
-        },
-        "sqlite3": {
-          "optional": true
-        }
+        "payload": "3.85.0"
       }
     },
     "node_modules/@payloadcms/graphql": {
-      "version": "3.84.1",
-      "resolved": "https://registry.npmjs.org/@payloadcms/graphql/-/graphql-3.84.1.tgz",
-      "integrity": "sha512-pVJdgihEEexpK+kANSozAMf3PQfd6p51/G3cK+rkPzSjghf7X+cQQ8NFOmAMDTpijM5YaowQYTuEje3KaLVXuQ==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@payloadcms/graphql/-/graphql-3.85.0.tgz",
+      "integrity": "sha512-QIAGSmtNS8XX5MxPZONMPX/xYANuzZ/xxAtlhFUxJvxTZVxbb1Aafx+dTIPTggJ4updzD3Rk/b76TYQc3jS13A==",
       "license": "MIT",
       "dependencies": {
         "graphql-scalars": "1.22.2",
@@ -3046,21 +2796,21 @@
       },
       "peerDependencies": {
         "graphql": "^16.8.1",
-        "payload": "3.84.1"
+        "payload": "3.85.0"
       }
     },
     "node_modules/@payloadcms/next": {
-      "version": "3.84.1",
-      "resolved": "https://registry.npmjs.org/@payloadcms/next/-/next-3.84.1.tgz",
-      "integrity": "sha512-T7f7Ja4l4Z6QM/oSM8MWJY63xyNQmWxUswDgssXl1/D0hQIVQASXMeZvXiXLQwg/g4f9s5anKTUNIx32dtHxWg==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@payloadcms/next/-/next-3.85.0.tgz",
+      "integrity": "sha512-9Q0kaKgd1CBl2Nu6QMISqRKfDlGraCkLWxKlWH59MO0Fu+vhvqhqEIv/gjzNj6wWMMH8e4yzFm8knZjTJTzzWQ==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/modifiers": "9.0.0",
         "@dnd-kit/sortable": "10.0.0",
-        "@payloadcms/graphql": "3.84.1",
-        "@payloadcms/translations": "3.84.1",
-        "@payloadcms/ui": "3.84.1",
+        "@payloadcms/graphql": "3.85.0",
+        "@payloadcms/translations": "3.85.0",
+        "@payloadcms/ui": "3.85.0",
         "busboy": "^1.6.0",
         "dequal": "2.0.3",
         "file-type": "21.3.4",
@@ -3070,21 +2820,21 @@
         "path-to-regexp": "6.3.0",
         "qs-esm": "8.0.1",
         "sass": "1.77.4",
-        "uuid": "11.1.0"
+        "uuid": "13.0.2"
       },
       "engines": {
         "node": "^18.20.2 || >=20.9.0"
       },
       "peerDependencies": {
         "graphql": "^16.8.1",
-        "next": ">=15.2.9 <15.3.0 || >=15.3.9 <15.4.0 || >=15.4.11 <15.5.0 || >=16.2.2 <17.0.0",
-        "payload": "3.84.1"
+        "next": ">=15.2.9 <15.3.0 || >=15.3.9 <15.4.0 || >=15.4.11 <15.5.0 || >=16.2.6 <17.0.0",
+        "payload": "3.85.0"
       }
     },
     "node_modules/@payloadcms/richtext-lexical": {
-      "version": "3.84.1",
-      "resolved": "https://registry.npmjs.org/@payloadcms/richtext-lexical/-/richtext-lexical-3.84.1.tgz",
-      "integrity": "sha512-KaNSz0RJFLnLc/hBRGg8Lgwk5FjCZSskA6KuufNWG5QdgUsgQe4Dx4Vr7G+VSR9zSZj+R4TVVSC0aVv4z7vL3g==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@payloadcms/richtext-lexical/-/richtext-lexical-3.85.0.tgz",
+      "integrity": "sha512-FZjDEJdkQNj0ZeQn4p4K56RbuNnRF2BrmWY2p0w856INZxngNDszfCbkhClvP++B0NgyMUqTVe7pappx9+vxWA==",
       "license": "MIT",
       "dependencies": {
         "@lexical/clipboard": "0.41.0",
@@ -3098,8 +2848,8 @@
         "@lexical/selection": "0.41.0",
         "@lexical/table": "0.41.0",
         "@lexical/utils": "0.41.0",
-        "@payloadcms/translations": "3.84.1",
-        "@payloadcms/ui": "3.84.1",
+        "@payloadcms/translations": "3.85.0",
+        "@payloadcms/ui": "3.85.0",
         "acorn": "8.16.0",
         "bson-objectid": "2.0.4",
         "csstype": "3.1.3",
@@ -3113,7 +2863,7 @@
         "qs-esm": "8.0.1",
         "react-error-boundary": "4.1.2",
         "ts-essentials": "10.0.3",
-        "uuid": "11.1.0"
+        "uuid": "13.0.2"
       },
       "engines": {
         "node": "^18.20.2 || >=20.9.0"
@@ -3121,25 +2871,25 @@
       "peerDependencies": {
         "@faceless-ui/modal": "3.0.0",
         "@faceless-ui/scroll-info": "2.0.0",
-        "@payloadcms/next": "3.84.1",
-        "payload": "3.84.1",
+        "@payloadcms/next": "3.85.0",
+        "payload": "3.85.0",
         "react": "^19.0.1 || ^19.1.2 || ^19.2.1",
         "react-dom": "^19.0.1 || ^19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@payloadcms/translations": {
-      "version": "3.84.1",
-      "resolved": "https://registry.npmjs.org/@payloadcms/translations/-/translations-3.84.1.tgz",
-      "integrity": "sha512-1g4IsXvRfeQCn8YmPweaj8MMAFK9oSxYWKJG15j+Ah9Nra+f35/ZdOt/k80+vfoJmdKsOK/AnuzVdSTWy2GQpg==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@payloadcms/translations/-/translations-3.85.0.tgz",
+      "integrity": "sha512-dZQc3OfVtp7IkL9R3e4t1n7MbDaKfhF6C6ewISOzJgkgrcdoCfrqXonwMYE4Ue6IDEqAtJuyEkOvFWew5tBHKw==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "4.1.0"
       }
     },
     "node_modules/@payloadcms/ui": {
-      "version": "3.84.1",
-      "resolved": "https://registry.npmjs.org/@payloadcms/ui/-/ui-3.84.1.tgz",
-      "integrity": "sha512-L9trD3/LcK1fiGg4AFexy9AQm4upMzRbicZFTNU/ac+x5o6Pwyr7FzrvbtfCr0l2t6QhawLBZmBCZJA8oBF2uA==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@payloadcms/ui/-/ui-3.85.0.tgz",
+      "integrity": "sha512-MMOZkj6Ztasqtl/kTiUKE0rnz35iPSiFDXuAfRyDqoqNf7vvWWRrtxa41kNAg++yZVAHBKPcMcMaugV6KiN0rQ==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "1.2.0",
@@ -3150,7 +2900,7 @@
         "@faceless-ui/scroll-info": "2.0.0",
         "@faceless-ui/window-info": "3.0.1",
         "@monaco-editor/react": "4.7.0",
-        "@payloadcms/translations": "3.84.1",
+        "@payloadcms/translations": "3.85.0",
         "bson-objectid": "2.0.4",
         "date-fns": "4.1.0",
         "dequal": "2.0.3",
@@ -3164,14 +2914,14 @@
         "sonner": "^1.7.2",
         "ts-essentials": "10.0.3",
         "use-context-selector": "2.0.0",
-        "uuid": "11.1.0"
+        "uuid": "13.0.2"
       },
       "engines": {
         "node": "^18.20.2 || >=20.9.0"
       },
       "peerDependencies": {
-        "next": ">=15.2.9 <15.3.0 || >=15.3.9 <15.4.0 || >=15.4.11 <15.5.0 || >=16.2.2 <17.0.0",
-        "payload": "3.84.1",
+        "next": ">=15.2.9 <15.3.0 || >=15.3.9 <15.4.0 || >=15.4.11 <15.5.0 || >=16.2.6 <17.0.0",
+        "payload": "3.85.0",
         "react": "^19.0.1 || ^19.1.2 || ^19.2.1",
         "react-dom": "^19.0.1 || ^19.1.2 || ^19.2.1"
       }
@@ -9447,6 +9197,131 @@
         "drizzle-kit": "bin.cjs"
       }
     },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -14669,13 +14544,13 @@
       "license": "MIT"
     },
     "node_modules/payload": {
-      "version": "3.84.1",
-      "resolved": "https://registry.npmjs.org/payload/-/payload-3.84.1.tgz",
-      "integrity": "sha512-+aPqqeYsffrzaYmsX/Qt+mHNgcTUyc5TIjjPOaMIrG6nDx6siZ2h9Gv3b3RKAVPt7PWkHI+ooEW3cQbwiDd99Q==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/payload/-/payload-3.85.0.tgz",
+      "integrity": "sha512-Cb3jX/WRkHhT5oZCx1BikR6fe32Xbld4Esxr0i+dXtHZMjBVgMjaf/oaK81jLRBstbJbUw7Ia/jMrRw82+FlwA==",
       "license": "MIT",
       "dependencies": {
         "@next/env": "^15.1.5",
-        "@payloadcms/translations": "3.84.1",
+        "@payloadcms/translations": "3.85.0",
         "@types/busboy": "1.5.4",
         "ajv": "8.18.0",
         "bson-objectid": "2.0.4",
@@ -14703,7 +14578,7 @@
         "ts-essentials": "10.0.3",
         "tsx": "4.21.0",
         "undici": "7.24.4",
-        "uuid": "11.1.0",
+        "uuid": "13.0.2",
         "ws": "^8.16.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "migrate:down": "payload migrate:down"
   },
   "dependencies": {
-    "@payloadcms/db-sqlite": "3.84.1",
-    "@payloadcms/next": "3.84.1",
-    "@payloadcms/richtext-lexical": "3.84.1",
-    "@payloadcms/ui": "3.84.1",
+    "@payloadcms/db-sqlite": "3.85.0",
+    "@payloadcms/next": "3.85.0",
+    "@payloadcms/richtext-lexical": "3.85.0",
+    "@payloadcms/ui": "3.85.0",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-navigation-menu": "^1.2.14",
     "@radix-ui/react-slot": "^1.2.4",
@@ -33,7 +33,7 @@
     "lucide-react": "^0.542.0",
     "next": "^16.2.6",
     "nodemailer": "^8.0.8",
-    "payload": "3.84.1",
+    "payload": "3.85.0",
     "radix-ui": "^1.4.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- Bumped `payload` and the first-party Payload packages to `3.85.0`
- Refreshed `package-lock.json` to keep the dependency graph aligned
- Picked up the corresponding Payload transitive updates, including the new `uuid` major used by the published packages

## Testing
- `npm run lint`
- `npm run test -- --run` (no test files found)
- `PAYLOAD_SECRET=... DATABASE_URI=file:/tmp/goldgetters-payload-upgrade.db NEXT_PUBLIC_TURNSTILE_SITE_KEY='' npm run ci`
- `npx prettier --check package.json package-lock.json`