### PR TITLE
Assign Dependabot PRs to robinpellegrims

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       day: 'monday'
       time: '08:00'
       timezone: 'Europe/Brussels'
+    assignees:
+      - 'robinpellegrims'
     commit-message:
       prefix: 'deps'
       prefix-development: 'deps-dev'
@@ -103,6 +105,8 @@ updates:
       day: 'monday'
       time: '08:30'
       timezone: 'Europe/Brussels'
+    assignees:
+      - 'robinpellegrims'
     commit-message:
       prefix: 'ci'
       include: 'scope'


### PR DESCRIPTION
## Summary
- Configure Dependabot to auto-assign npm and CI update pull requests to `robinpellegrims`
- Keep existing commit message prefixes and scheduling unchanged

## Testing
- Not run (not requested)